### PR TITLE
feat: add JSON Schema generation for TypeScript types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
 				"svelte": "^5.0.0",
 				"svelte-check": "^4.0.0",
 				"terser": "^5.43.1",
+				"ts-json-schema-generator": "^2.4.0",
 				"typescript": "^5.0.0",
 				"typescript-eslint": "^8.20.0",
 				"vite": "^6.2.6",
@@ -1088,6 +1089,29 @@
 				}
 			}
 		},
+		"node_modules/@isaacs/balanced-match": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+			"integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/@isaacs/brace-expansion": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+			"integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@isaacs/balanced-match": "^4.0.1"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
 		"node_modules/@isaacs/cliui": {
 			"version": "8.0.2",
 			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -1490,6 +1514,7 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -2070,6 +2095,7 @@
 			"integrity": "sha512-BmV0nU3Ot1fHE1MTlmrmJpEdmQCXZJH+2zQx457ZrJLYFyozG7fyirx5zBXTnH6agyOF7CsjqtMHp2MhX8YVnw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"ts-dedent": "^2.0.0",
 				"type-fest": "~2.19"
@@ -2187,6 +2213,7 @@
 			"integrity": "sha512-dCYqelr2RVnWUuxc+Dk/dB/SjV/8JBndp1UovCyCZdIQezd8TRwFLNZctYkzgHxRJtaNvseCSRsuuHPeUgIN/A==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@standard-schema/spec": "^1.0.0",
 				"@sveltejs/acorn-typescript": "^1.0.5",
@@ -2253,6 +2280,7 @@
 			"integrity": "sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@sveltejs/vite-plugin-svelte-inspector": "^4.0.1",
 				"debug": "^4.4.1",
@@ -2293,6 +2321,7 @@
 			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.10.4",
 				"@babel/runtime": "^7.12.5",
@@ -2573,6 +2602,7 @@
 			"integrity": "sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.46.2",
 				"@typescript-eslint/types": "8.46.2",
@@ -2791,6 +2821,7 @@
 			"integrity": "sha512-tJxiPrWmzH8a+w9nLKlQMzAKX/7VjFs50MWgcAj7p9XQ7AQ9/35fByFYptgPELyLw+0aixTnC4pUWV+APcZ/kw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@testing-library/dom": "^10.4.0",
 				"@testing-library/user-event": "^14.6.1",
@@ -2918,6 +2949,7 @@
 			"integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@vitest/utils": "3.2.4",
 				"pathe": "^2.0.3",
@@ -2961,6 +2993,7 @@
 			"integrity": "sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@vitest/utils": "3.2.4",
 				"fflate": "^0.8.2",
@@ -3027,6 +3060,7 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -3523,8 +3557,7 @@
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
 			"integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/d3-color": {
 			"version": "3.1.0",
@@ -3583,6 +3616,7 @@
 			"resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
 			"integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
 			"license": "ISC",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -3808,6 +3842,7 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"esbuild": "bin/esbuild"
 			},
@@ -3885,6 +3920,7 @@
 			"integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -4448,6 +4484,7 @@
 			"integrity": "sha512-QsCdAUHAmiDeKeaNojb1OHOPF7NjcWPBR7obdu3NwH2a/oyQaLg5d0aaCy/9My6CdPChYF07dvz5chaXBGaD4g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/node": "^20.0.0",
 				"@types/whatwg-mimetype": "^3.0.2",
@@ -4796,6 +4833,19 @@
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/json5": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"json5": "lib/cli.js"
+			},
+			"engines": {
+				"node": ">=6"
+			}
 		},
 		"node_modules/jsonfile": {
 			"version": "6.2.0",
@@ -5527,6 +5577,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -5660,6 +5711,7 @@
 			"integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -5799,6 +5851,7 @@
 			"integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -5809,6 +5862,7 @@
 			"integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"scheduler": "^0.27.0"
 			},
@@ -5948,6 +6002,7 @@
 			"integrity": "sha512-3GuObel8h7Kqdjt0gxkEzaifHTqLVW56Y/bjN7PSQtkKr0w3V/QYSdt6QWYtd7A1xUtYQigtdUfgj1RvWVtorw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/estree": "1.0.8"
 			},
@@ -6041,6 +6096,16 @@
 				}
 			],
 			"license": "MIT"
+		},
+		"node_modules/safe-stable-stringify": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+			"integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			}
 		},
 		"node_modules/scheduler": {
 			"version": "0.27.0",
@@ -6215,6 +6280,7 @@
 			"integrity": "sha512-kfr6kxQAjA96ADlH6FMALJwJ+eM80UqXy106yVHNgdsAP/CdzkkicglRAhZAvUycXK9AeadF6KZ00CWLtVMN4w==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@storybook/global": "^5.0.0",
 				"@testing-library/jest-dom": "^6.6.3",
@@ -6445,6 +6511,7 @@
 			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.41.3.tgz",
 			"integrity": "sha512-bkHg+whEnVVNcK3XP8Dy4NHujn5mU/+at9z09PXM5THKm+E73AwiKFoRMMTfyAzAj1yExKtudvGHq8UqOh8kMQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@jridgewell/remapping": "^2.3.4",
 				"@jridgewell/sourcemap-codec": "^1.5.0",
@@ -6564,21 +6631,6 @@
 				}
 			}
 		},
-		"node_modules/svelte-check/node_modules/picomatch": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
 		"node_modules/svelte-eslint-parser": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-1.4.0.tgz",
@@ -6673,6 +6725,7 @@
 			"integrity": "sha512-nIVck8DK+GM/0Frwd+nIhZ84pR/BX7rmXMfYwyg+Sri5oGVE99/E3KvXqpC2xHFxyqXyGHTKBSioxxplrO4I4w==",
 			"dev": true,
 			"license": "BSD-2-Clause",
+			"peer": true,
 			"dependencies": {
 				"@jridgewell/source-map": "^0.3.3",
 				"acorn": "^8.15.0",
@@ -6799,6 +6852,7 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -6925,6 +6979,122 @@
 				"node": ">=6.10"
 			}
 		},
+		"node_modules/ts-json-schema-generator": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/ts-json-schema-generator/-/ts-json-schema-generator-2.4.0.tgz",
+			"integrity": "sha512-HbmNsgs58CfdJq0gpteRTxPXG26zumezOs+SB9tgky6MpqiFgQwieCn2MW70+sxpHouZ/w9LW0V6L4ZQO4y1Ug==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/json-schema": "^7.0.15",
+				"commander": "^13.1.0",
+				"glob": "^11.0.1",
+				"json5": "^2.2.3",
+				"normalize-path": "^3.0.0",
+				"safe-stable-stringify": "^2.5.0",
+				"tslib": "^2.8.1",
+				"typescript": "^5.8.2"
+			},
+			"bin": {
+				"ts-json-schema-generator": "bin/ts-json-schema-generator.js"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/ts-json-schema-generator/node_modules/commander": {
+			"version": "13.1.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+			"integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/ts-json-schema-generator/node_modules/glob": {
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+			"integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"foreground-child": "^3.3.1",
+				"jackspeak": "^4.1.1",
+				"minimatch": "^10.1.1",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^2.0.0"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/ts-json-schema-generator/node_modules/jackspeak": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
+			"integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"@isaacs/cliui": "^8.0.2"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/ts-json-schema-generator/node_modules/lru-cache": {
+			"version": "11.2.4",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+			"integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/ts-json-schema-generator/node_modules/minimatch": {
+			"version": "10.1.1",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+			"integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"@isaacs/brace-expansion": "^5.0.0"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/ts-json-schema-generator/node_modules/path-scurry": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
+			"integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^11.0.0",
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/tslib": {
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -6964,6 +7134,7 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -7086,6 +7257,7 @@
 			"integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.25.0",
 				"fdir": "^6.4.4",
@@ -7230,6 +7402,7 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -7263,6 +7436,7 @@
 			"integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/chai": "^5.2.2",
 				"@vitest/expect": "3.2.4",
@@ -7517,21 +7691,6 @@
 			"license": "ISC",
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/yaml": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-			"integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
-			"dev": true,
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"bin": {
-				"yaml": "bin.mjs"
-			},
-			"engines": {
-				"node": ">= 14.6"
 			}
 		},
 		"node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
 		"test:all": "npm run test && npm run test:e2e",
 		"format": "prettier --write .",
 		"storybook": "storybook dev -p 6006",
-		"build-storybook": "storybook build"
+		"build-storybook": "storybook build",
+		"generate:schemas": "node scripts/generate-schemas.js"
 	},
 	"watch": {
 		"build": {
@@ -66,6 +67,7 @@
 	},
 	"files": [
 		"dist",
+		"schemas",
 		"!dist/**/*.test.*",
 		"!dist/**/*.spec.*"
 	],
@@ -124,7 +126,13 @@
 			"default": "./dist/playground/index.js"
 		},
 		"./styles": "./dist/styles/base.css",
-		"./styles/*": "./dist/styles/*"
+		"./styles/*": "./dist/styles/*",
+		"./schemas/node-metadata": "./schemas/node-metadata.schema.json",
+		"./schemas/config-schema": "./schemas/config-schema.schema.json",
+		"./schemas/port-config": "./schemas/port-config.schema.json",
+		"./schemas/node-port": "./schemas/node-port.schema.json",
+		"./schemas/config-property": "./schemas/config-property.schema.json",
+		"./schemas/*": "./schemas/*"
 	},
 	"peerDependencies": {
 		"@iconify/svelte": "^5.0.0",
@@ -177,6 +185,7 @@
 		"svelte": "^5.0.0",
 		"svelte-check": "^4.0.0",
 		"terser": "^5.43.1",
+		"ts-json-schema-generator": "^2.4.0",
 		"typescript": "^5.0.0",
 		"typescript-eslint": "^8.20.0",
 		"vite": "^6.2.6",

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,0 +1,76 @@
+# FlowDrop JSON Schemas
+
+This directory contains JSON Schema files generated from FlowDrop's TypeScript types.
+These schemas can be used by backend implementations to validate the JSON they produce
+for the FlowDrop editor.
+
+## Available Schemas
+
+| Schema | Description |
+|--------|-------------|
+| `node-metadata.schema.json` | Schema for node type definitions (NodeMetadata) |
+| `config-schema.schema.json` | Schema for node configuration schemas (ConfigSchema) |
+| `config-property.schema.json` | Schema for individual config properties (ConfigProperty) |
+| `node-port.schema.json` | Schema for node port definitions (NodePort) |
+| `port-config.schema.json` | Schema for port configuration system (PortConfig) |
+
+## Usage
+
+### In JavaScript/TypeScript
+
+```typescript
+import nodeMetadataSchema from '@d34dman/flowdrop/schemas/node-metadata.schema.json';
+import Ajv from 'ajv';
+
+const ajv = new Ajv();
+const validate = ajv.compile(nodeMetadataSchema);
+
+const myNodeType = {
+  id: 'my-node',
+  name: 'My Node',
+  // ...
+};
+
+if (!validate(myNodeType)) {
+  console.error('Validation errors:', validate.errors);
+}
+```
+
+### In Rust
+
+Using the `jsonschema` crate:
+
+```rust
+use jsonschema::JSONSchema;
+use serde_json::json;
+
+let schema = serde_json::from_str(include_str!("node-metadata.schema.json"))?;
+let compiled = JSONSchema::compile(&schema)?;
+
+let node_metadata = json!({
+    "id": "my-node",
+    "name": "My Node",
+    // ...
+});
+
+if let Err(errors) = compiled.validate(&node_metadata) {
+    for error in errors {
+        eprintln!("Validation error: {}", error);
+    }
+}
+```
+
+## Regenerating Schemas
+
+To regenerate schemas after modifying TypeScript types:
+
+```bash
+npm run generate:schemas
+```
+
+This requires `ts-json-schema-generator` to be installed (already in devDependencies).
+
+## Schema Source
+
+Schemas are generated from `src/lib/types/schema-types.ts`, which re-exports types
+from the main types file (`src/lib/types/index.ts`) that don't have Svelte dependencies.

--- a/schemas/config-property.schema.json
+++ b/schemas/config-property.schema.json
@@ -1,0 +1,73 @@
+{
+  "$ref": "#/definitions/ConfigProperty",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "ConfigProperty": {
+      "additionalProperties": {
+        "anyOf": [
+          {},
+          {}
+        ]
+      },
+      "description": "Configuration schema property with specific attributes",
+      "properties": {
+        "default": {},
+        "description": {
+          "type": "string"
+        },
+        "enum": {
+          "items": {},
+          "type": "array"
+        },
+        "format": {
+          "type": "string"
+        },
+        "items": {
+          "$ref": "#/definitions/ConfigProperty"
+        },
+        "maxLength": {
+          "type": "number"
+        },
+        "maximum": {
+          "type": "number"
+        },
+        "minLength": {
+          "type": "number"
+        },
+        "minimum": {
+          "type": "number"
+        },
+        "multiple": {
+          "type": "boolean"
+        },
+        "pattern": {
+          "type": "string"
+        },
+        "properties": {
+          "additionalProperties": {
+            "$ref": "#/definitions/ConfigProperty"
+          },
+          "type": "object"
+        },
+        "title": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "string",
+            "number",
+            "boolean",
+            "array",
+            "object",
+            "integer"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/schemas/config-schema.schema.json
+++ b/schemas/config-schema.schema.json
@@ -1,0 +1,103 @@
+{
+  "$ref": "#/definitions/ConfigSchema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "ConfigProperty": {
+      "additionalProperties": {
+        "anyOf": [
+          {},
+          {}
+        ]
+      },
+      "description": "Configuration schema property with specific attributes",
+      "properties": {
+        "default": {},
+        "description": {
+          "type": "string"
+        },
+        "enum": {
+          "items": {},
+          "type": "array"
+        },
+        "format": {
+          "type": "string"
+        },
+        "items": {
+          "$ref": "#/definitions/ConfigProperty"
+        },
+        "maxLength": {
+          "type": "number"
+        },
+        "maximum": {
+          "type": "number"
+        },
+        "minLength": {
+          "type": "number"
+        },
+        "minimum": {
+          "type": "number"
+        },
+        "multiple": {
+          "type": "boolean"
+        },
+        "pattern": {
+          "type": "string"
+        },
+        "properties": {
+          "additionalProperties": {
+            "$ref": "#/definitions/ConfigProperty"
+          },
+          "type": "object"
+        },
+        "title": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "string",
+            "number",
+            "boolean",
+            "array",
+            "object",
+            "integer"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "ConfigSchema": {
+      "additionalProperties": false,
+      "description": "Configuration schema interface",
+      "properties": {
+        "additionalProperties": {
+          "type": "boolean"
+        },
+        "properties": {
+          "additionalProperties": {
+            "$ref": "#/definitions/ConfigProperty"
+          },
+          "type": "object"
+        },
+        "required": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "type": {
+          "const": "object",
+          "type": "string"
+        }
+      },
+      "required": [
+        "properties",
+        "type"
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/schemas/node-metadata.schema.json
+++ b/schemas/node-metadata.schema.json
@@ -1,0 +1,442 @@
+{
+  "$ref": "#/definitions/NodeMetadata",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "BuiltinNodeType": {
+      "description": "Built-in node types for explicit component rendering. These are the node types that ship with FlowDrop.",
+      "enum": [
+        "note",
+        "simple",
+        "square",
+        "tool",
+        "gateway",
+        "terminal",
+        "default"
+      ],
+      "type": "string"
+    },
+    "ConfigEditOptions": {
+      "additionalProperties": false,
+      "description": "Admin/Edit configuration for nodes with dynamic or external configuration Used when the config schema cannot be determined at workflow load time or when configuration is handled by a 3rd party system.",
+      "properties": {
+        "dynamicSchema": {
+          "$ref": "#/definitions/DynamicSchemaEndpoint",
+          "description": "Dynamic schema endpoint configuration When configured, fetches the config schema from the specified endpoint"
+        },
+        "errorMessage": {
+          "default": "Failed to load configuration. Use external editor instead.",
+          "description": "Message to display when schema fetch fails",
+          "type": "string"
+        },
+        "externalEditLink": {
+          "$ref": "#/definitions/ExternalEditLink",
+          "description": "External link configuration for 3rd party form When configured, shows a link/button to open external configuration"
+        },
+        "loadingMessage": {
+          "default": "Loading configuration options...",
+          "description": "Message to display when schema is being loaded",
+          "type": "string"
+        },
+        "preferDynamicSchema": {
+          "default": "false (prefer external link)",
+          "description": "When both externalEditLink and dynamicSchema are configured, determines which to use by default",
+          "type": "boolean"
+        },
+        "showRefreshButton": {
+          "default": true,
+          "description": "Show a \"Refresh Schema\" button when using dynamic schema Allows users to manually refresh the schema",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "ConfigProperty": {
+      "additionalProperties": {
+        "anyOf": [
+          {},
+          {}
+        ]
+      },
+      "description": "Configuration schema property with specific attributes",
+      "properties": {
+        "default": {},
+        "description": {
+          "type": "string"
+        },
+        "enum": {
+          "items": {},
+          "type": "array"
+        },
+        "format": {
+          "type": "string"
+        },
+        "items": {
+          "$ref": "#/definitions/ConfigProperty"
+        },
+        "maxLength": {
+          "type": "number"
+        },
+        "maximum": {
+          "type": "number"
+        },
+        "minLength": {
+          "type": "number"
+        },
+        "minimum": {
+          "type": "number"
+        },
+        "multiple": {
+          "type": "boolean"
+        },
+        "pattern": {
+          "type": "string"
+        },
+        "properties": {
+          "additionalProperties": {
+            "$ref": "#/definitions/ConfigProperty"
+          },
+          "type": "object"
+        },
+        "title": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "string",
+            "number",
+            "boolean",
+            "array",
+            "object",
+            "integer"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "ConfigSchema": {
+      "additionalProperties": false,
+      "description": "Configuration schema interface",
+      "properties": {
+        "additionalProperties": {
+          "type": "boolean"
+        },
+        "properties": {
+          "additionalProperties": {
+            "$ref": "#/definitions/ConfigProperty"
+          },
+          "type": "object"
+        },
+        "required": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "type": {
+          "const": "object",
+          "type": "string"
+        }
+      },
+      "required": [
+        "properties",
+        "type"
+      ],
+      "type": "object"
+    },
+    "DynamicSchemaEndpoint": {
+      "additionalProperties": false,
+      "description": "Dynamic schema endpoint configuration Used when the config schema needs to be fetched at runtime from a REST endpoint",
+      "properties": {
+        "body": {
+          "additionalProperties": {},
+          "description": "Request body for POST/PUT/PATCH methods. Can include template variables like the URL.",
+          "type": "object"
+        },
+        "cacheSchema": {
+          "default": true,
+          "description": "Whether to cache the fetched schema per node instance",
+          "type": "boolean"
+        },
+        "headers": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom headers to include in the request",
+          "type": "object"
+        },
+        "method": {
+          "$ref": "#/definitions/HttpMethod",
+          "default": "GET",
+          "description": "HTTP method to use for fetching the schema."
+        },
+        "parameterMapping": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Maps template variables to their source paths. Keys are variable names used in the URL, values are dot-notation paths to resolve from the node context (e.g., \"metadata.id\", \"config.apiKey\", \"id\")",
+          "type": "object"
+        },
+        "timeout": {
+          "default": 10000,
+          "description": "Timeout in milliseconds for the schema fetch request",
+          "type": "number"
+        },
+        "url": {
+          "description": "The URL to fetch the schema from. Supports template variables in curly braces (e.g., \"/api/nodes/{nodeTypeId}/schema\") Variables are resolved from node metadata, config, or instance data.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "url"
+      ],
+      "type": "object"
+    },
+    "ExternalEditLink": {
+      "additionalProperties": false,
+      "description": "External edit link configuration Used when the node configuration should be handled by an external 3rd party form",
+      "properties": {
+        "callbackUrlParam": {
+          "description": "Callback URL parameter name for FlowDrop to receive updates If set, the external form should redirect back with config updates",
+          "type": "string"
+        },
+        "description": {
+          "description": "Optional tooltip/description for the link",
+          "type": "string"
+        },
+        "icon": {
+          "default": "heroicons:arrow-top-right-on-square",
+          "description": "Icon to display alongside the label (Iconify icon name)",
+          "type": "string"
+        },
+        "label": {
+          "default": "Configure Externally",
+          "description": "Display label for the edit link button",
+          "type": "string"
+        },
+        "openInNewTab": {
+          "default": true,
+          "description": "Whether to open the link in a new tab",
+          "type": "boolean"
+        },
+        "parameterMapping": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Maps template variables to their source paths. Keys are variable names used in the URL, values are dot-notation paths to resolve from the node context (e.g., \"metadata.id\", \"config.apiKey\", \"id\")",
+          "type": "object"
+        },
+        "url": {
+          "description": "The URL to the external edit form. Supports template variables in curly braces (e.g., \"/admin/nodes/{nodeTypeId}/edit\") Variables are resolved from node metadata, config, or instance data.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "url"
+      ],
+      "type": "object"
+    },
+    "HttpMethod": {
+      "description": "HTTP method types for dynamic schema endpoints",
+      "enum": [
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH"
+      ],
+      "type": "string"
+    },
+    "NodeCategory": {
+      "description": "Node category types for organizing nodes in the sidebar Based on actual API response categories",
+      "enum": [
+        "inputs",
+        "outputs",
+        "prompts",
+        "models",
+        "processing",
+        "logic",
+        "data",
+        "tools",
+        "helpers",
+        "vector stores",
+        "embeddings",
+        "memories",
+        "agents",
+        "ai",
+        "bundles"
+      ],
+      "type": "string"
+    },
+    "NodeDataType": {
+      "description": "Node data type - now dynamic based on configuration Will be string literals of available data type IDs",
+      "type": "string"
+    },
+    "NodeExtensions": {
+      "additionalProperties": {
+        "description": "Namespaced extension data from 3rd party integrations Use your package/organization name as the key (e.g., \"myapp\", \"acme:analyzer\")"
+      },
+      "description": "Custom extension properties for 3rd party integrations Allows storing additional configuration and UI state data",
+      "properties": {
+        "configEdit": {
+          "$ref": "#/definitions/ConfigEditOptions",
+          "description": "Per-instance admin/edit configuration override Allows overriding the node type's configEdit settings for specific instances"
+        },
+        "ui": {
+          "$ref": "#/definitions/NodeUIExtensions",
+          "description": "UI-related settings for the node Used to control visual behavior in the workflow editor"
+        }
+      },
+      "type": "object"
+    },
+    "NodeMetadata": {
+      "additionalProperties": false,
+      "description": "Node configuration metadata",
+      "properties": {
+        "category": {
+          "$ref": "#/definitions/NodeCategory"
+        },
+        "color": {
+          "type": "string"
+        },
+        "config": {
+          "additionalProperties": {},
+          "description": "Default configuration values for this node type",
+          "type": "object"
+        },
+        "configEdit": {
+          "$ref": "#/definitions/ConfigEditOptions",
+          "description": "Admin/Edit configuration for nodes with dynamic or external configuration. Used when the config schema cannot be determined at workflow load time or when configuration is handled by a 3rd party system.\n\nSupports two options: 1. External edit link - Opens a 3rd party form in a new tab 2. Dynamic schema - Fetches the config schema from a REST endpoint"
+        },
+        "configSchema": {
+          "$ref": "#/definitions/ConfigSchema"
+        },
+        "description": {
+          "type": "string"
+        },
+        "extensions": {
+          "$ref": "#/definitions/NodeExtensions",
+          "description": "Custom extension properties for 3rd party integrations Allows storing additional configuration and UI state data at the node type level"
+        },
+        "icon": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "inputs": {
+          "items": {
+            "$ref": "#/definitions/NodePort"
+          },
+          "type": "array"
+        },
+        "name": {
+          "type": "string"
+        },
+        "outputs": {
+          "items": {
+            "$ref": "#/definitions/NodePort"
+          },
+          "type": "array"
+        },
+        "supportedTypes": {
+          "description": "Array of supported node types that this node can be rendered as. If not specified, defaults to the single 'type' field or 'default'. This allows nodes to support multiple rendering modes (e.g., both 'simple' and 'default'). Can include both built-in types and custom registered types.",
+          "items": {
+            "$ref": "#/definitions/NodeType"
+          },
+          "type": "array"
+        },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "type": {
+          "$ref": "#/definitions/NodeType"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "description",
+        "category",
+        "version",
+        "inputs",
+        "outputs"
+      ],
+      "type": "object"
+    },
+    "NodePort": {
+      "additionalProperties": false,
+      "description": "Node port configuration",
+      "properties": {
+        "dataType": {
+          "$ref": "#/definitions/NodeDataType"
+        },
+        "defaultValue": {},
+        "description": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "type": {
+          "enum": [
+            "input",
+            "output",
+            "metadata"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "type",
+        "dataType"
+      ],
+      "type": "object"
+    },
+    "NodeType": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/BuiltinNodeType"
+        },
+        {
+          "type": "string"
+        }
+      ],
+      "description": "Node type for component rendering. Includes built-in types and allows custom registered types.\n\nBuilt-in types: note, simple, square, tool, gateway, terminal, default Custom types: Any string registered via nodeComponentRegistry"
+    },
+    "NodeUIExtensions": {
+      "additionalProperties": {
+        "description": "Any other UI-specific settings"
+      },
+      "description": "UI-related extension settings for nodes Used to control visual behavior in the workflow editor",
+      "properties": {
+        "hideUnconnectedHandles": {
+          "description": "Show/hide unconnected handles (ports) to reduce visual noise",
+          "type": "boolean"
+        },
+        "style": {
+          "additionalProperties": {},
+          "description": "Custom styles or theme overrides",
+          "type": "object"
+        }
+      },
+      "type": "object"
+    }
+  }
+}

--- a/schemas/node-port.schema.json
+++ b/schemas/node-port.schema.json
@@ -1,0 +1,47 @@
+{
+  "$ref": "#/definitions/NodePort",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "NodeDataType": {
+      "description": "Node data type - now dynamic based on configuration Will be string literals of available data type IDs",
+      "type": "string"
+    },
+    "NodePort": {
+      "additionalProperties": false,
+      "description": "Node port configuration",
+      "properties": {
+        "dataType": {
+          "$ref": "#/definitions/NodeDataType"
+        },
+        "defaultValue": {},
+        "description": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "type": {
+          "enum": [
+            "input",
+            "output",
+            "metadata"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "type",
+        "dataType"
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/schemas/port-config.schema.json
+++ b/schemas/port-config.schema.json
@@ -1,0 +1,106 @@
+{
+  "$ref": "#/definitions/PortConfig",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "PortCompatibilityRule": {
+      "additionalProperties": false,
+      "description": "Port compatibility rule configuration Simple rule: sourceType can connect TO targetType",
+      "properties": {
+        "description": {
+          "description": "Optional description of why this connection is allowed",
+          "type": "string"
+        },
+        "from": {
+          "description": "Source data type ID (what you're connecting FROM)",
+          "type": "string"
+        },
+        "to": {
+          "description": "Target data type ID (what you're connecting TO)",
+          "type": "string"
+        }
+      },
+      "required": [
+        "from",
+        "to"
+      ],
+      "type": "object"
+    },
+    "PortConfig": {
+      "additionalProperties": false,
+      "description": "Complete port configuration system",
+      "properties": {
+        "compatibilityRules": {
+          "description": "Compatibility rules between data types",
+          "items": {
+            "$ref": "#/definitions/PortCompatibilityRule"
+          },
+          "type": "array"
+        },
+        "dataTypes": {
+          "description": "Available data types",
+          "items": {
+            "$ref": "#/definitions/PortDataTypeConfig"
+          },
+          "type": "array"
+        },
+        "defaultDataType": {
+          "description": "Default data type to use when none specified",
+          "type": "string"
+        },
+        "version": {
+          "description": "Version of the port configuration",
+          "type": "string"
+        }
+      },
+      "required": [
+        "dataTypes",
+        "compatibilityRules",
+        "defaultDataType"
+      ],
+      "type": "object"
+    },
+    "PortDataTypeConfig": {
+      "additionalProperties": false,
+      "description": "Port data type configuration",
+      "properties": {
+        "aliases": {
+          "description": "Alternative names/aliases for this data type",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "category": {
+          "description": "Category grouping for the data type",
+          "type": "string"
+        },
+        "color": {
+          "description": "Color for the data type (CSS color value)",
+          "type": "string"
+        },
+        "description": {
+          "description": "Description of the data type",
+          "type": "string"
+        },
+        "enabled": {
+          "description": "Whether this data type is enabled",
+          "type": "boolean"
+        },
+        "id": {
+          "description": "Unique identifier for the data type",
+          "type": "string"
+        },
+        "name": {
+          "description": "Display name for the data type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "color"
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/scripts/generate-schemas.js
+++ b/scripts/generate-schemas.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+/**
+ * Generate JSON Schemas from TypeScript types
+ * 
+ * This script generates JSON Schema files for FlowDrop's core types,
+ * allowing backend implementations to validate the JSON they produce.
+ * 
+ * Usage:
+ *   npm run generate:schemas
+ * 
+ * Output:
+ *   schemas/node-metadata.schema.json - Schema for NodeMetadata
+ *   schemas/config-schema.schema.json - Schema for ConfigSchema
+ *   schemas/port-config.schema.json   - Schema for PortConfig
+ */
+
+import { execSync } from 'child_process';
+import { mkdirSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const rootDir = join(__dirname, '..');
+const schemasDir = join(rootDir, 'schemas');
+
+// Ensure schemas directory exists
+if (!existsSync(schemasDir)) {
+  mkdirSync(schemasDir, { recursive: true });
+}
+
+// Types to generate schemas for
+const types = [
+  { name: 'NodeMetadata', output: 'node-metadata.schema.json' },
+  { name: 'ConfigSchema', output: 'config-schema.schema.json' },
+  { name: 'PortConfig', output: 'port-config.schema.json' },
+  { name: 'NodePort', output: 'node-port.schema.json' },
+  { name: 'ConfigProperty', output: 'config-property.schema.json' },
+];
+
+console.log('Generating JSON Schemas from TypeScript types...\n');
+
+for (const type of types) {
+  const outputPath = join(schemasDir, type.output);
+  console.log(`  Generating ${type.name} -> ${type.output}`);
+  
+  try {
+    execSync(
+      `npx ts-json-schema-generator ` +
+      `--path "src/lib/types/schema-types.ts" ` +
+      `--type "${type.name}" ` +
+      `--tsconfig tsconfig.json ` +
+      `--no-type-check ` +
+      `--out "${outputPath}"`,
+      { cwd: rootDir, stdio: 'pipe' }
+    );
+    console.log(`    ✓ Generated ${type.output}`);
+  } catch (error) {
+    console.error(`    ✗ Failed to generate ${type.name}: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+console.log('\nDone! Schemas written to schemas/ directory.');

--- a/src/lib/types/schema-types.ts
+++ b/src/lib/types/schema-types.ts
@@ -1,0 +1,42 @@
+/**
+ * Schema-only types for JSON Schema generation
+ * 
+ * This file re-exports types that are safe for JSON Schema generation,
+ * excluding types that depend on Svelte or other runtime dependencies.
+ * 
+ * Generated schemas are used by backend implementations to validate
+ * the JSON they produce for the FlowDrop editor.
+ */
+
+// Re-export types that don't have Svelte dependencies
+export type {
+  NodeCategory,
+  PortDataTypeConfig,
+  PortCompatibilityRule,
+  PortConfig,
+  NodeDataType,
+  NodePort,
+  DynamicPort,
+  Branch,
+  BuiltinNodeType,
+  NodeType,
+  HttpMethod,
+  DynamicSchemaEndpoint,
+  ExternalEditLink,
+  ConfigEditOptions,
+  NodeUIExtensions,
+  NodeExtensions,
+  NodeMetadata,
+  BaseProperty,
+  BaseSchema,
+  ConfigProperty,
+  ConfigSchema,
+  InputProperty,
+  InputSchema,
+  OutputProperty,
+  OutputSchema,
+  Schema,
+  Property,
+  SchemaType,
+  ConfigValues,
+} from './index.js';


### PR DESCRIPTION
## Summary

Add tooling to generate JSON Schema files from FlowDrop's TypeScript type definitions. This allows backend implementations to validate the JSON they produce for the FlowDrop editor at build time or runtime.

Closes #7

## Changes

- Add `ts-json-schema-generator` as dev dependency
- Add `src/lib/types/schema-types.ts` with Svelte-free type re-exports
- Add `scripts/generate-schemas.js` for schema generation
- Add npm script: `generate:schemas`
- Export schemas via package.json exports
- Generate initial schemas for core types:
  - `NodeMetadata`
  - `ConfigSchema`
  - `ConfigProperty`
  - `NodePort`
  - `PortConfig`

## Usage

Generate schemas:
```bash
npm run generate:schemas
```

Import schemas in consuming projects:
```typescript
import schema from '@d34dman/flowdrop/schemas/node-metadata.schema.json';
```

Or use the files directly from the `schemas/` directory.

## Use Case

Backend implementations (like Rust, Go, PHP) can validate their node type JSON against these schemas to catch incompatibilities early, rather than discovering them at runtime in the editor.

Example validation error this caught in my Rust backend:
```
Additional properties are not allowed ('cacheTtl' was unexpected) at /configEdit/dynamicSchema
```

This revealed that my Rust types had `cacheTtl` while FlowDrop uses `timeout` + `cacheSchema`.