### PR TITLE
fix: draw edge arrowheads at path base instead of tip

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -3,7 +3,7 @@ name: Deploy API Documentation
 on:
   push:
     branches:
-      - 1.x
+      - main
     paths:
       - 'libs/flowdrop/api/**'
       - 'apps/api-docs/**'

--- a/.github/workflows/api-lint.yml
+++ b/.github/workflows/api-lint.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - 1.x
     paths:
       - 'libs/flowdrop/api/**'
       - 'apps/api-docs/**'
@@ -12,7 +11,6 @@ on:
   pull_request:
     branches:
       - main
-      - 1.x
     paths:
       - 'libs/flowdrop/api/**'
       - 'apps/api-docs/**'

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,13 +4,11 @@ on:
   push:
     branches:
       - main
-      - 1.x
     tags:
       - 'v*'
   pull_request:
     branches:
       - main
-      - 1.x
 
 env:
   REGISTRY: ghcr.io

--- a/apps/api-docs/README.md
+++ b/apps/api-docs/README.md
@@ -85,7 +85,7 @@ libs/flowdrop/api/
 
 ## Deployment
 
-Documentation is automatically deployed to GitHub Pages on every push to the `1.x` branch (or via manual workflow dispatch). See [`.github/workflows/api-docs.yml`](../../.github/workflows/api-docs.yml) for the full pipeline.
+Documentation is automatically deployed to GitHub Pages on every push to the `main` branch (or via manual workflow dispatch). See [`.github/workflows/api-docs.yml`](../../.github/workflows/api-docs.yml) for the full pipeline.
 
 ## Key Files
 

--- a/libs/flowdrop/api/README.md
+++ b/libs/flowdrop/api/README.md
@@ -121,7 +121,7 @@ The API spec is validated in CI:
 
 ## Hosted Documentation
 
-API documentation is automatically deployed to GitHub Pages on every push to `1.x`:
+API documentation is automatically deployed to GitHub Pages on every push to `main`:
 
 **https://flowdrop-io.github.io/flowdrop/**
 

--- a/libs/flowdrop/package.json
+++ b/libs/flowdrop/package.json
@@ -1,8 +1,13 @@
 {
 	"name": "@flowdrop/flowdrop",
+	"description": "A drop-in visual workflow editor for any web application. You own the backend. You own the data. You own the orchestration.",
 	"license": "MIT",
 	"private": false,
 	"version": "1.0.0",
+	"author": "Shibin Das (D34dMan)",
+	"bugs": {
+		"url": "https://github.com/flowdrop-io/flowdrop/issues"
+	},
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build && pnpm run prepack",
@@ -260,17 +265,24 @@
 			"cookie": "0.7.2"
 		}
 	},
+	"engines": {
+		"node": ">=18"
+	},
 	"keywords": [
 		"svelte",
 		"svelte5",
 		"workflow",
+		"workflow-editor",
 		"editor",
 		"node-editor",
 		"graph-editor",
 		"visual-programming",
 		"xyflow",
 		"flowchart",
-		"dag"
+		"dag",
+		"agent",
+		"ai-workflow",
+		"embeddable"
 	],
 	"dependencies": {
 		"diff": "^8.0.3",

--- a/libs/flowdrop/src/lib/components/FlowDropEdge.stories.svelte
+++ b/libs/flowdrop/src/lib/components/FlowDropEdge.stories.svelte
@@ -1,0 +1,161 @@
+<script module>
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import EdgeDecorator from '../../lib/stories/EdgeDecorator.svelte';
+	import { createSampleNodeData } from '../../lib/stories/utils.js';
+	import { EDGE_MARKER_SIZES } from '../../lib/config/constants.js';
+
+	const { Story } = defineMeta({
+		title: 'Edges/FlowDropEdge',
+		tags: ['autodocs'],
+		parameters: {
+			layout: 'centered'
+		}
+	});
+
+	const sourceNode = createSampleNodeData({
+		label: 'Text Input',
+		metadata: {
+			id: 'text_input',
+			name: 'Text Input',
+			description: 'Simple text input',
+			category: 'inputs',
+			version: '1.0.0',
+			type: 'simple',
+			icon: 'mdi:text',
+			color: '#22c55e',
+			inputs: [],
+			outputs: [
+				{ id: 'output', name: 'Output', type: 'output', dataType: 'string', required: false }
+			]
+		}
+	});
+
+	const targetNode = createSampleNodeData({
+		label: 'Text Output',
+		metadata: {
+			id: 'text_output',
+			name: 'Text Output',
+			description: 'Display text output',
+			category: 'outputs',
+			version: '1.0.0',
+			type: 'simple',
+			icon: 'mdi:text-box',
+			color: '#ef4444',
+			inputs: [
+				{ id: 'input', name: 'Input', type: 'input', dataType: 'string', required: false }
+			],
+			outputs: []
+		}
+	});
+
+	const triggerSource = createSampleNodeData({
+		label: 'Trigger Source',
+		metadata: {
+			id: 'trigger_source',
+			name: 'Trigger Source',
+			description: 'Emits a trigger signal',
+			category: 'processing',
+			version: '1.0.0',
+			type: 'simple',
+			icon: 'mdi:play',
+			color: '#3b82f6',
+			inputs: [],
+			outputs: [
+				{ id: 'trigger', name: 'Trigger', type: 'output', dataType: 'trigger', required: false }
+			]
+		}
+	});
+
+	const triggerTarget = createSampleNodeData({
+		label: 'Trigger Target',
+		metadata: {
+			id: 'trigger_target',
+			name: 'Trigger Target',
+			description: 'Receives a trigger signal',
+			category: 'processing',
+			version: '1.0.0',
+			type: 'simple',
+			icon: 'mdi:lightning-bolt',
+			color: '#8b5cf6',
+			inputs: [
+				{ id: 'trigger', name: 'Trigger', type: 'input', dataType: 'trigger', required: false }
+			],
+			outputs: []
+		}
+	});
+
+	const toolSource = createSampleNodeData({
+		label: 'Tool Provider',
+		metadata: {
+			id: 'tool_provider',
+			name: 'Tool Provider',
+			description: 'Provides a tool',
+			category: 'processing',
+			version: '1.0.0',
+			type: 'simple',
+			icon: 'mdi:wrench',
+			color: '#f59e0b',
+			inputs: [],
+			outputs: [
+				{ id: 'tool', name: 'Tool', type: 'output', dataType: 'tool', required: false }
+			]
+		}
+	});
+
+	const toolTarget = createSampleNodeData({
+		label: 'Tool Consumer',
+		metadata: {
+			id: 'tool_consumer',
+			name: 'Tool Consumer',
+			description: 'Consumes a tool',
+			category: 'processing',
+			version: '1.0.0',
+			type: 'simple',
+			icon: 'mdi:cog',
+			color: '#f59e0b',
+			inputs: [
+				{ id: 'tool', name: 'Tool', type: 'input', dataType: 'tool', required: false }
+			],
+			outputs: []
+		}
+	});
+</script>
+
+<Story name="Data Edge">
+	<EdgeDecorator
+		sourceData={sourceNode}
+		targetData={targetNode}
+		edgeStyle="stroke: var(--fd-edge-data, #64748b);"
+		edgeClass="flowdrop--edge--data"
+		edgeMarkerColor="#64748b"
+		edgeMarkerSize={EDGE_MARKER_SIZES.data}
+		sourceHandleId="output"
+		targetHandleId="input"
+	/>
+</Story>
+
+<Story name="Trigger Edge">
+	<EdgeDecorator
+		sourceData={triggerSource}
+		targetData={triggerTarget}
+		edgeStyle="stroke: var(--fd-edge-trigger, #1e293b); stroke-width: 2px;"
+		edgeClass="flowdrop--edge--trigger"
+		edgeMarkerColor="#1e293b"
+		edgeMarkerSize={EDGE_MARKER_SIZES.trigger}
+		sourceHandleId="trigger"
+		targetHandleId="trigger"
+	/>
+</Story>
+
+<Story name="Tool Edge">
+	<EdgeDecorator
+		sourceData={toolSource}
+		targetData={toolTarget}
+		edgeStyle="stroke: var(--fd-edge-tool, #f59e0b); stroke-dasharray: 5 3;"
+		edgeClass="flowdrop--edge--tool"
+		edgeMarkerColor="#f59e0b"
+		edgeMarkerSize={EDGE_MARKER_SIZES.tool}
+		sourceHandleId="tool"
+		targetHandleId="tool"
+	/>
+</Story>

--- a/libs/flowdrop/src/lib/components/FlowDropEdge.svelte
+++ b/libs/flowdrop/src/lib/components/FlowDropEdge.svelte
@@ -1,0 +1,168 @@
+<!--
+  FlowDropEdge Component
+  Custom bezier edge that draws its own arrowhead so the line stroke ends
+  at the arrow base instead of poking through to the tip.
+
+  Approach:
+  1. Compute the full bezier path (xyflow's getBezierPath)
+  2. Parse the SVG path to extract the cubic bezier control points
+  3. Evaluate the curve near the end to get the true visual tangent
+  4. Shorten the path along that tangent and draw the arrowhead at the target
+-->
+
+<script lang="ts">
+	import { getBezierPath } from '@xyflow/svelte';
+	import { BaseEdge } from '@xyflow/svelte';
+	import type { BezierEdgeProps } from '@xyflow/svelte';
+	import { ARROW_LENGTH_PX, ARROW_HALF_WIDTH_PX } from '../config/constants.js';
+
+	let {
+		id,
+		interactionWidth,
+		label,
+		labelStyle,
+		markerEnd: _markerEnd,
+		markerStart,
+		pathOptions,
+		sourcePosition,
+		sourceX,
+		sourceY,
+		style,
+		targetPosition,
+		targetX,
+		targetY
+	}: BezierEdgeProps = $props();
+
+	/**
+	 * Extract stroke color from the edge's inline style for the arrowhead fill.
+	 */
+	let strokeColor = $derived.by(() => {
+		if (!style) return 'var(--fd-edge-data, #64748b)';
+		const match = style.match(/stroke:\s*([^;]+)/);
+		return match ? match[1].trim() : 'var(--fd-edge-data, #64748b)';
+	});
+
+	/**
+	 * Evaluate a cubic bezier at parameter t.
+	 * P(t) = (1-t)^3 * P0 + 3(1-t)^2 * t * P1 + 3(1-t) * t^2 * P2 + t^3 * P3
+	 */
+	function bezierAt(
+		p0x: number,
+		p0y: number,
+		p1x: number,
+		p1y: number,
+		p2x: number,
+		p2y: number,
+		p3x: number,
+		p3y: number,
+		t: number
+	): { x: number; y: number } {
+		const u = 1 - t;
+		const uu = u * u;
+		const uuu = uu * u;
+		const tt = t * t;
+		const ttt = tt * t;
+		return {
+			x: uuu * p0x + 3 * uu * t * p1x + 3 * u * tt * p2x + ttt * p3x,
+			y: uuu * p0y + 3 * uu * t * p1y + 3 * u * tt * p2y + ttt * p3y
+		};
+	}
+
+	/**
+	 * Parse the SVG cubic bezier path "M x0,y0 C x1,y1 x2,y2 x3,y3"
+	 * into the four control points.
+	 */
+	function parseCubicBezier(d: string) {
+		const nums = d.match(/-?[\d.]+/g)?.map(Number);
+		if (!nums || nums.length < 8) return null;
+		return {
+			p0x: nums[0],
+			p0y: nums[1],
+			p1x: nums[2],
+			p1y: nums[3],
+			p2x: nums[4],
+			p2y: nums[5],
+			p3x: nums[6],
+			p3y: nums[7]
+		};
+	}
+
+	// Parameter near the end of the curve for tangent sampling
+	const T_SAMPLE = 0.9;
+
+	let computed = $derived.by(() => {
+		// 1. Get the full bezier path from xyflow
+		const [fullPath, lx, ly] = getBezierPath({
+			sourceX,
+			sourceY,
+			targetX,
+			targetY,
+			sourcePosition,
+			targetPosition,
+			curvature: pathOptions?.curvature
+		});
+
+		// 2. Parse control points from SVG path
+		const cp = parseCubicBezier(fullPath);
+		if (!cp) {
+			return { path: fullPath, labelX: lx, labelY: ly, angleDeg: 0 };
+		}
+
+		// 3. Evaluate the curve at T_SAMPLE to get a reference point
+		const ref = bezierAt(
+			cp.p0x,
+			cp.p0y,
+			cp.p1x,
+			cp.p1y,
+			cp.p2x,
+			cp.p2y,
+			cp.p3x,
+			cp.p3y,
+			T_SAMPLE
+		);
+
+		// 4. Tangent direction: from reference point to the target
+		const dx = targetX - ref.x;
+		const dy = targetY - ref.y;
+		const angleDeg = (Math.atan2(dy, dx) * 180) / Math.PI;
+		const angleRad = Math.atan2(dy, dx);
+
+		// 5. Shorten: move the endpoint back along the tangent
+		const adjX = targetX - Math.cos(angleRad) * ARROW_LENGTH_PX;
+		const adjY = targetY - Math.sin(angleRad) * ARROW_LENGTH_PX;
+
+		// 6. Recompute the bezier path with the shortened target
+		const [shortenedPath] = getBezierPath({
+			sourceX,
+			sourceY,
+			targetX: adjX,
+			targetY: adjY,
+			sourcePosition,
+			targetPosition,
+			curvature: pathOptions?.curvature
+		});
+
+		return { path: shortenedPath, labelX: lx, labelY: ly, angleDeg };
+	});
+</script>
+
+<BaseEdge
+	{id}
+	path={computed.path}
+	labelX={computed.labelX}
+	labelY={computed.labelY}
+	{label}
+	{labelStyle}
+	{markerStart}
+	{interactionWidth}
+	{style}
+/>
+
+<!-- Manual arrowhead: tip at origin pointing right, rotated to the bezier tangent -->
+<polygon
+	points="0,0 {-ARROW_LENGTH_PX},{-ARROW_HALF_WIDTH_PX} {-ARROW_LENGTH_PX},{ARROW_HALF_WIDTH_PX}"
+	fill={strokeColor}
+	stroke="none"
+	transform="translate({targetX},{targetY}) rotate({computed.angleDeg})"
+	class="flowdrop-edge-arrow"
+/>

--- a/libs/flowdrop/src/lib/components/WorkflowEditor.svelte
+++ b/libs/flowdrop/src/lib/components/WorkflowEditor.svelte
@@ -33,6 +33,7 @@
 	import { tick, untrack } from 'svelte';
 	import type { EndpointConfig } from '../config/endpoints.js';
 	import ConnectionLine from './ConnectionLine.svelte';
+	import FlowDropEdge from './FlowDropEdge.svelte';
 	import { getWorkflowStore, workflowActions } from '../stores/workflowStore.svelte.js';
 	import { historyActions, setOnRestoreCallback } from '../stores/historyStore.svelte.js';
 	import UniversalNode from './UniversalNode.svelte';
@@ -329,6 +330,11 @@
 	// All nodes use 'universalNode' type, and UniversalNode handles internal switching
 	const nodeTypes = {
 		universalNode: UniversalNode
+	};
+
+	// Use custom edge that shortens the path so the stroke ends at the arrow base
+	const edgeTypes = {
+		default: FlowDropEdge
 	};
 
 	// Handle arrows in our custom connection handler
@@ -759,6 +765,7 @@
 							bind:nodes={flowNodes}
 							bind:edges={flowEdges}
 							{nodeTypes}
+							{edgeTypes}
 							{defaultEdgeOptions}
 							onconnect={(connection) =>
 								void handleConnect({

--- a/libs/flowdrop/src/lib/config/constants.ts
+++ b/libs/flowdrop/src/lib/config/constants.ts
@@ -19,6 +19,15 @@ export const PIPELINE_API_UNAVAILABLE_DURATION_MS = 5 * 60 * 1000;
 /** Default cache TTL for schema and variable data in milliseconds (5 minutes) */
 export const DEFAULT_CACHE_TTL_MS = 5 * 60 * 1000;
 
+/**
+ * Custom arrowhead dimensions (in pixels) drawn by FlowDropEdge.
+ * The edge path is shortened by ARROW_LENGTH_PX so the stroke ends
+ * at the arrow base, and the arrowhead polygon is rendered separately
+ * at the target handle position.
+ */
+export const ARROW_LENGTH_PX = 8;
+export const ARROW_HALF_WIDTH_PX = 4;
+
 /** Edge marker arrow sizes by category */
 export const EDGE_MARKER_SIZES = {
 	loopback: { width: 14, height: 14 },

--- a/libs/flowdrop/src/lib/services/api.ts
+++ b/libs/flowdrop/src/lib/services/api.ts
@@ -255,15 +255,17 @@ export const workflowApi = {
 	},
 
 	/**
-	 * Save workflow (create or update)
+	 * Save workflow (create or update).
+	 *
+	 * A workflow is considered existing when it already has an id (any format —
+	 * integer, UUID, slug). Only a missing/empty id means "truly new".
+	 *
+	 * Note: globalSave.ts bypasses this method and calls createWorkflow /
+	 * updateWorkflow directly so it can capture the new/existing decision before
+	 * the uuidv4() fallback. This method is kept for external callers.
 	 */
 	async saveWorkflow(workflow: Workflow): Promise<Workflow> {
-		// Check if this is an existing workflow by looking for a valid ID
-		// Valid IDs should not be a UUID (which indicates a new workflow)
-		const isExistingWorkflow =
-			workflow.id &&
-			workflow.id.length > 0 &&
-			!workflow.id.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+		const isExistingWorkflow = !!(workflow.id && workflow.id.length > 0);
 
 		if (isExistingWorkflow) {
 			// Update existing workflow

--- a/libs/flowdrop/src/lib/services/globalSave.ts
+++ b/libs/flowdrop/src/lib/services/globalSave.ts
@@ -172,6 +172,11 @@ export async function globalSaveWorkflow(options: GlobalSaveOptions = {}): Promi
 
 		// Step 3 — Build the canonical workflow object.
 		// Preserve all existing metadata fields (format, tags, etc.) so nothing is dropped.
+		//
+		// Determine new vs existing BEFORE the uuidv4() fallback: if the store already
+		// has an id (any format — integer, UUID, slug), the workflow came from a backend
+		// and must be updated. Only a missing id means "truly new".
+		const isExistingWorkflow = !!currentWorkflow.id;
 		const workflowId = currentWorkflow.id || uuidv4();
 
 		const finalWorkflow: Workflow = {
@@ -193,11 +198,6 @@ export async function globalSaveWorkflow(options: GlobalSaveOptions = {}): Promi
 		let savedWorkflow: Workflow;
 
 		if (apiClient) {
-			// Enhanced client path — detects existing workflows by non-UUID ID
-			const isExistingWorkflow =
-				finalWorkflow.id.length > 0 &&
-				!finalWorkflow.id.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
-
 			if (isExistingWorkflow) {
 				savedWorkflow = await apiClient.updateWorkflow(finalWorkflow.id, finalWorkflow);
 			} else {
@@ -205,7 +205,12 @@ export async function globalSaveWorkflow(options: GlobalSaveOptions = {}): Promi
 			}
 		} else {
 			// Legacy path
-			savedWorkflow = await workflowApi.saveWorkflow(finalWorkflow);
+			if (isExistingWorkflow) {
+				savedWorkflow = await workflowApi.updateWorkflow(finalWorkflow.id, finalWorkflow);
+			} else {
+				const { id: _id, ...workflowData } = finalWorkflow;
+				savedWorkflow = await workflowApi.createWorkflow(workflowData);
+			}
 		}
 
 		// Step 5 — If the server assigned a new ID, sync the store

--- a/libs/flowdrop/src/lib/stories/EdgeDecorator.svelte
+++ b/libs/flowdrop/src/lib/stories/EdgeDecorator.svelte
@@ -1,0 +1,122 @@
+<!--
+  EdgeDecorator: Renders two connected nodes inside a SvelteFlow canvas
+  to showcase edge rendering with arrowhead markers.
+-->
+<script lang="ts">
+	import { SvelteFlow, Controls, MarkerType } from '@xyflow/svelte';
+	import type { Node, Edge, ColorMode } from '@xyflow/svelte';
+	import '@xyflow/svelte/dist/style.css';
+	import UniversalNode from '$lib/components/UniversalNode.svelte';
+	import FlowDropEdge from '$lib/components/FlowDropEdge.svelte';
+	import { registerBuiltinNodes } from '$lib/registry/builtinNodes.js';
+	import { EDGE_MARKER_SIZES } from '$lib/config/constants.js';
+
+	interface Props {
+		sourceData: Record<string, unknown>;
+		targetData: Record<string, unknown>;
+		edgeStyle?: string;
+		edgeClass?: string;
+		edgeMarkerColor?: string;
+		edgeMarkerSize?: { width: number; height: number };
+		sourceHandleId?: string;
+		targetHandleId?: string;
+	}
+
+	let {
+		sourceData,
+		targetData,
+		edgeStyle = 'stroke: #64748b;',
+		edgeClass = 'flowdrop--edge--data',
+		edgeMarkerColor = '#64748b',
+		edgeMarkerSize = EDGE_MARKER_SIZES.data,
+		sourceHandleId = 'output',
+		targetHandleId = 'input'
+	}: Props = $props();
+
+	registerBuiltinNodes();
+
+	const nodeTypes = {
+		universalNode: UniversalNode
+	};
+
+	const edgeTypes = {
+		default: FlowDropEdge
+	};
+
+	const SOURCE_ID = 'source-node';
+	const TARGET_ID = 'target-node';
+
+	let nodes = $state<Node[]>([
+		{
+			id: SOURCE_ID,
+			type: 'universalNode',
+			position: { x: 0, y: 0 },
+			data: { ...sourceData, nodeId: SOURCE_ID }
+		},
+		{
+			id: TARGET_ID,
+			type: 'universalNode',
+			position: { x: 350, y: 0 },
+			data: { ...targetData, nodeId: TARGET_ID }
+		}
+	]);
+
+	// Handle IDs follow the format: {nodeId}-{input|output}-{portId}
+	let edges = $state<Edge[]>([
+		{
+			id: 'edge-1',
+			source: SOURCE_ID,
+			target: TARGET_ID,
+			sourceHandle: `${SOURCE_ID}-output-${sourceHandleId}`,
+			targetHandle: `${TARGET_ID}-input-${targetHandleId}`,
+			style: edgeStyle,
+			class: edgeClass,
+			markerEnd: {
+				type: MarkerType.ArrowClosed,
+				...edgeMarkerSize,
+				color: edgeMarkerColor
+			}
+		}
+	]);
+
+	let colorMode = $state<ColorMode>(
+		(document.documentElement.getAttribute('data-theme') as ColorMode) || 'light'
+	);
+
+	$effect(() => {
+		const observer = new MutationObserver(() => {
+			colorMode = (document.documentElement.getAttribute('data-theme') as ColorMode) || 'light';
+		});
+		observer.observe(document.documentElement, {
+			attributes: true,
+			attributeFilter: ['data-theme']
+		});
+		return () => observer.disconnect();
+	});
+</script>
+
+<div class="edge-decorator-wrapper">
+	<SvelteFlow
+		bind:nodes
+		bind:edges
+		{nodeTypes}
+		{edgeTypes}
+		fitView
+		fitViewOptions={{ maxZoom: 0.85, padding: 0.3 }}
+		{colorMode}
+	>
+		<Controls />
+	</SvelteFlow>
+</div>
+
+<style>
+	.edge-decorator-wrapper {
+		width: 900px;
+		height: 400px;
+		position: relative;
+	}
+
+	.edge-decorator-wrapper :global(.svelte-flow.dark) {
+		--background-color-default: var(--xy-background-color-default);
+	}
+</style>

--- a/libs/flowdrop/tests/e2e/editor-save.spec.ts
+++ b/libs/flowdrop/tests/e2e/editor-save.spec.ts
@@ -61,6 +61,61 @@ test.describe('Save Workflow', () => {
 		}
 	});
 
+	test('save uses PUT when workflow already has a UUID id (regression: issue #26)', async ({
+		page
+	}) => {
+		const backendUUID = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+		let saveMethod: string | null = null;
+		let savePath: string | null = null;
+
+		// Intercept the initial workflow load and return one with a UUID id
+		await page.route('**/api/flowdrop/workflows/**', async (route) => {
+			const method = route.request().method();
+			if (method === 'GET') {
+				await route.fulfill({
+					status: 200,
+					contentType: 'application/json',
+					body: JSON.stringify({
+						success: true,
+						data: {
+							id: backendUUID,
+							name: 'UUID Workflow',
+							description: '',
+							nodes: [],
+							edges: [],
+							metadata: { version: '1.0.0' }
+						}
+					})
+				});
+			} else if (method === 'PUT' || method === 'POST') {
+				saveMethod = method;
+				savePath = new URL(route.request().url()).pathname;
+				await route.fulfill({
+					status: 200,
+					contentType: 'application/json',
+					body: JSON.stringify({
+						success: true,
+						data: { id: backendUUID },
+						message: 'Workflow saved'
+					})
+				});
+			} else {
+				await route.continue();
+			}
+		});
+
+		await gotoEditor(page, 'simple');
+
+		const saveButton = page.locator('.flowdrop-navbar__primary-action', { hasText: 'Save' });
+		await expect(saveButton).toBeVisible({ timeout: 5000 });
+		await saveButton.click();
+		await page.waitForTimeout(2000);
+
+		// Must use PUT (update), not POST (create)
+		expect(saveMethod).toBe('PUT');
+		expect(savePath).toContain(backendUUID);
+	});
+
 	test('save button is visible in navbar', async ({ page }) => {
 		await gotoEditor(page, 'simple');
 

--- a/libs/flowdrop/tests/unit/services/api.test.ts
+++ b/libs/flowdrop/tests/unit/services/api.test.ts
@@ -391,7 +391,10 @@ describe('API Service', () => {
 		});
 
 		describe('saveWorkflow', () => {
-			it('should create new workflow when id is UUID', async () => {
+			it('should update existing workflow when id is a UUID (regression: issue #26)', async () => {
+				// Previously a UUID regex caused UUID ids to be treated as new workflows,
+				// resulting in duplicate POSTs instead of PUTs. Any non-empty id is now
+				// treated as an existing workflow regardless of format.
 				const workflow = createTestWorkflow({
 					id: '550e8400-e29b-41d4-a716-446655440000'
 				});
@@ -401,16 +404,16 @@ describe('API Service', () => {
 				await workflowApi.saveWorkflow(workflow);
 
 				expect(global.fetch).toHaveBeenCalledWith(
-					'/api/flowdrop/workflows',
+					'/api/flowdrop/workflows/550e8400-e29b-41d4-a716-446655440000',
 					expect.objectContaining({
-						method: 'POST'
+						method: 'PUT'
 					})
 				);
 			});
 
 			it('should update existing workflow when id is not UUID', async () => {
 				const workflow = createTestWorkflow({
-					id: '123' // Non-UUID id indicates existing workflow
+					id: '123'
 				});
 
 				global.fetch = vi.fn(() => Promise.resolve(mockFetchResponse(workflow)));

--- a/libs/flowdrop/tests/unit/services/globalSave.test.ts
+++ b/libs/flowdrop/tests/unit/services/globalSave.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Unit Tests - Global Save Service
+ *
+ * Tests for the globalSaveWorkflow() function, focusing on correct routing
+ * between createWorkflow (POST) and updateWorkflow (PUT) based on whether
+ * the workflow already has a backend-assigned id.
+ *
+ * Regression coverage for: UUID Workflow ID Bug (issue #26)
+ * Previously a UUID regex was used to detect new workflows, which caused
+ * backends that use UUIDs as primary keys to always POST instead of PUT.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { globalSaveWorkflow } from '$lib/services/globalSave.js';
+import { createTestWorkflow } from '../../utils/index.js';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+// vi.mock factories are hoisted to the top of the file, so variables they
+// reference must be initialised with vi.hoisted() to be available in time.
+const {
+	mockGetWorkflowStore,
+	mockWorkflowActionsBatchUpdate,
+	mockStoreMarkAsSaved,
+	mockCreateWorkflow,
+	mockUpdateWorkflow,
+	mockGetEndpointConfig
+} = vi.hoisted(() => ({
+	mockGetWorkflowStore: vi.fn(),
+	mockWorkflowActionsBatchUpdate: vi.fn(),
+	mockStoreMarkAsSaved: vi.fn(),
+	mockCreateWorkflow: vi.fn(),
+	mockUpdateWorkflow: vi.fn(),
+	mockGetEndpointConfig: vi.fn()
+}));
+
+vi.mock('$lib/stores/workflowStore.svelte.js', () => ({
+	getWorkflowStore: (...args: unknown[]) => mockGetWorkflowStore(...args),
+	workflowActions: { batchUpdate: (...args: unknown[]) => mockWorkflowActionsBatchUpdate(...args) },
+	markAsSaved: (...args: unknown[]) => mockStoreMarkAsSaved(...args)
+}));
+
+vi.mock('$lib/services/api.js', () => ({
+	workflowApi: {
+		createWorkflow: (...args: unknown[]) => mockCreateWorkflow(...args),
+		updateWorkflow: (...args: unknown[]) => mockUpdateWorkflow(...args),
+		saveWorkflow: vi.fn()
+	},
+	getEndpointConfig: (...args: unknown[]) => mockGetEndpointConfig(...args),
+	setEndpointConfig: vi.fn()
+}));
+
+vi.mock('$lib/services/toastService.js', () => ({
+	apiToasts: { loading: vi.fn(() => 'toast-id'), error: vi.fn() },
+	workflowToasts: { saved: vi.fn() },
+	dismissToast: vi.fn()
+}));
+
+vi.mock('$lib/config/endpoints.js', () => ({
+	createEndpointConfig: vi.fn(() => ({ baseUrl: '/api/flowdrop' }))
+}));
+
+vi.mock('svelte', () => ({
+	tick: () => Promise.resolve()
+}));
+
+const FIXED_UUID = 'aaaabbbb-cccc-dddd-eeee-ffffaaaabbbb';
+vi.mock('uuid', () => ({ v4: () => FIXED_UUID }));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Returns a workflow with the given id (use '' or undefined for new) */
+function storeWorkflow(id: string) {
+	return createTestWorkflow({ id });
+}
+
+/** Saved workflow returned by the backend */
+function backendWorkflow(id: string) {
+	return createTestWorkflow({ id });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('globalSaveWorkflow', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		// Simulate a valid endpoint config so ensureApiConfiguration exits early
+		mockGetEndpointConfig.mockReturnValue({ baseUrl: '/api/flowdrop' });
+	});
+
+	// -------------------------------------------------------------------------
+	// Legacy path (no apiClient)
+	// -------------------------------------------------------------------------
+
+	describe('legacy path (no apiClient)', () => {
+		it('calls createWorkflow when workflow has no id (new workflow)', async () => {
+			const workflow = storeWorkflow('');
+			mockGetWorkflowStore.mockReturnValue(workflow);
+			mockCreateWorkflow.mockResolvedValue(backendWorkflow('server-assigned-id'));
+
+			await globalSaveWorkflow({});
+
+			expect(mockCreateWorkflow).toHaveBeenCalledTimes(1);
+			expect(mockUpdateWorkflow).not.toHaveBeenCalled();
+
+			// id should be stripped from the POST body
+			const [postedWorkflow] = mockCreateWorkflow.mock.calls[0];
+			expect(postedWorkflow).not.toHaveProperty('id');
+		});
+
+		it('calls updateWorkflow when workflow has a non-UUID id (existing workflow)', async () => {
+			const workflow = storeWorkflow('123');
+			mockGetWorkflowStore.mockReturnValue(workflow);
+			mockUpdateWorkflow.mockResolvedValue(backendWorkflow('123'));
+
+			await globalSaveWorkflow({});
+
+			expect(mockUpdateWorkflow).toHaveBeenCalledTimes(1);
+			expect(mockUpdateWorkflow).toHaveBeenCalledWith('123', expect.objectContaining({ id: '123' }));
+			expect(mockCreateWorkflow).not.toHaveBeenCalled();
+		});
+
+		it('calls updateWorkflow when workflow has a UUID id (regression: issue #26)', async () => {
+			const uuidId = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+			const workflow = storeWorkflow(uuidId);
+			mockGetWorkflowStore.mockReturnValue(workflow);
+			mockUpdateWorkflow.mockResolvedValue(backendWorkflow(uuidId));
+
+			await globalSaveWorkflow({});
+
+			expect(mockUpdateWorkflow).toHaveBeenCalledTimes(1);
+			expect(mockUpdateWorkflow).toHaveBeenCalledWith(
+				uuidId,
+				expect.objectContaining({ id: uuidId })
+			);
+			expect(mockCreateWorkflow).not.toHaveBeenCalled();
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Enhanced client path
+	// -------------------------------------------------------------------------
+
+	describe('enhanced client path (apiClient provided)', () => {
+		const mockApiClientSave = vi.fn();
+		const mockApiClientUpdate = vi.fn();
+		const apiClient = {
+			saveWorkflow: (...args: unknown[]) => mockApiClientSave(...args),
+			updateWorkflow: (...args: unknown[]) => mockApiClientUpdate(...args)
+		};
+
+		it('calls apiClient.saveWorkflow when workflow has no id (new workflow)', async () => {
+			mockGetWorkflowStore.mockReturnValue(storeWorkflow(''));
+			mockApiClientSave.mockResolvedValue(backendWorkflow('server-uuid'));
+
+			await globalSaveWorkflow({ apiClient });
+
+			expect(mockApiClientSave).toHaveBeenCalledTimes(1);
+			expect(mockApiClientUpdate).not.toHaveBeenCalled();
+		});
+
+		it('calls apiClient.updateWorkflow when workflow has a UUID id (regression: issue #26)', async () => {
+			const uuidId = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+			mockGetWorkflowStore.mockReturnValue(storeWorkflow(uuidId));
+			mockApiClientUpdate.mockResolvedValue(backendWorkflow(uuidId));
+
+			await globalSaveWorkflow({ apiClient });
+
+			expect(mockApiClientUpdate).toHaveBeenCalledTimes(1);
+			expect(mockApiClientUpdate).toHaveBeenCalledWith(
+				uuidId,
+				expect.objectContaining({ id: uuidId })
+			);
+			expect(mockApiClientSave).not.toHaveBeenCalled();
+		});
+
+		it('calls apiClient.updateWorkflow when workflow has a non-UUID id', async () => {
+			mockGetWorkflowStore.mockReturnValue(storeWorkflow('slug-workflow'));
+			mockApiClientUpdate.mockResolvedValue(backendWorkflow('slug-workflow'));
+
+			await globalSaveWorkflow({ apiClient });
+
+			expect(mockApiClientUpdate).toHaveBeenCalledWith(
+				'slug-workflow',
+				expect.objectContaining({ id: 'slug-workflow' })
+			);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Event handler hooks
+	// -------------------------------------------------------------------------
+
+	describe('event handlers', () => {
+		it('cancels save when onBeforeSave returns false', async () => {
+			mockGetWorkflowStore.mockReturnValue(storeWorkflow(''));
+			const onBeforeSave = vi.fn().mockResolvedValue(false);
+
+			await globalSaveWorkflow({ eventHandlers: { onBeforeSave } });
+
+			expect(mockCreateWorkflow).not.toHaveBeenCalled();
+			expect(mockUpdateWorkflow).not.toHaveBeenCalled();
+		});
+
+		it('proceeds with save when onBeforeSave returns true', async () => {
+			mockGetWorkflowStore.mockReturnValue(storeWorkflow(''));
+			mockCreateWorkflow.mockResolvedValue(backendWorkflow('new-id'));
+			const onBeforeSave = vi.fn().mockResolvedValue(true);
+
+			await globalSaveWorkflow({ eventHandlers: { onBeforeSave } });
+
+			expect(mockCreateWorkflow).toHaveBeenCalledTimes(1);
+		});
+
+		it('calls onAfterSave with the saved workflow on success', async () => {
+			const saved = backendWorkflow('backend-id');
+			mockGetWorkflowStore.mockReturnValue(storeWorkflow(''));
+			mockCreateWorkflow.mockResolvedValue(saved);
+			const onAfterSave = vi.fn().mockResolvedValue(undefined);
+
+			await globalSaveWorkflow({ eventHandlers: { onAfterSave } });
+
+			expect(onAfterSave).toHaveBeenCalledWith(saved);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Guard: no workflow in store
+	// -------------------------------------------------------------------------
+
+	it('returns early without making any API call when store is empty', async () => {
+		mockGetWorkflowStore.mockReturnValue(null);
+
+		await globalSaveWorkflow({});
+
+		expect(mockCreateWorkflow).not.toHaveBeenCalled();
+		expect(mockUpdateWorkflow).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary

- Custom `FlowDropEdge` component that replaces xyflow's default bezier edge
- Draws arrowheads as manual SVG polygons instead of using xyflow's built-in SVG markers (which place the arrow tip at the same point as the line endpoint)
- Computes the true bezier curve tangent by evaluating the curve near the endpoint (t=0.9), so the arrowhead rotates naturally with the curve direction
- Edge path is shortened along the tangent so the stroke ends cleanly at the arrow base

## Files changed

- **FlowDropEdge.svelte** — custom edge component with manual arrowhead rendering
- **WorkflowEditor.svelte** — registers `FlowDropEdge` as the default edge type
- **constants.ts** — arrow dimension constants (`ARROW_LENGTH_PX`, `ARROW_HALF_WIDTH_PX`)
- **EdgeDecorator.svelte** — storybook decorator for edge stories
- **FlowDropEdge.stories.svelte** — stories for Data, Trigger, and Tool edge types

## Test plan

- [x] Open storybook (`npm run storybook`), check **Edges / FlowDropEdge** stories
- [x] Verify arrowhead is visible and line ends at arrow base (not tip)
- [ ] Test in the workflow editor: connect nodes, verify arrows on all edge types (data, trigger, tool, loopback)
- [x] Zoom in on arrowheads to confirm no stroke bleeds through
- [x] Test with different node positions (horizontal, vertical, diagonal)