### PR TITLE
feat(form): expose form values + autocomplete hooks for custom dependent components

### DIFF
--- a/libs/flowdrop/package.json
+++ b/libs/flowdrop/package.json
@@ -108,6 +108,11 @@
       "svelte": "./dist/form/index.js",
       "default": "./dist/form/index.js"
     },
+    "./form/autocomplete": {
+      "types": "./dist/form/autocomplete.d.ts",
+      "svelte": "./dist/form/autocomplete.js",
+      "default": "./dist/form/autocomplete.js"
+    },
     "./form/code": {
       "types": "./dist/form/code.d.ts",
       "svelte": "./dist/form/code.js",

--- a/libs/flowdrop/src/lib/components/ConfigForm.svelte
+++ b/libs/flowdrop/src/lib/components/ConfigForm.svelte
@@ -108,6 +108,10 @@
   // Use getter functions to ensure child components always get the current prop value,
   // even if the prop changes after initial mount
   setContext<() => AuthProvider | undefined>('flowdrop:getAuthProvider', () => authProvider);
+  // Expose the current form values so custom field components registered via
+  // fieldComponentRegistry can read sibling field values (e.g. for dependent
+  // autocomplete fields whose fetch URL depends on another field's value).
+  setContext<() => Record<string, unknown>>('flowdrop:getFormValues', () => configValues);
 
   /**
    * State for dynamic schema loading

--- a/libs/flowdrop/src/lib/components/form/FormField.svelte
+++ b/libs/flowdrop/src/lib/components/form/FormField.svelte
@@ -41,6 +41,7 @@
   import FormMarkdownEditor from './FormMarkdownEditor.svelte';
   import FormTemplateEditor from './FormTemplateEditor.svelte';
   import FormAutocomplete from './FormAutocomplete.svelte';
+  import { fieldComponentRegistry } from '../../form/fieldRegistry.js';
   import type { FieldSchema } from './types.js';
   import { getSchemaOptions } from './types.js';
   import type { WorkflowNode, WorkflowEdge, AuthProvider } from '$lib/types/index.js';
@@ -101,6 +102,12 @@
    * Animation delay based on index
    */
   const animationDelay = $derived(animationIndex * 30);
+
+  /**
+   * Check field registry for a custom component matching this schema (e.g. a
+   * dependent autocomplete component contributed by a consumer).
+   */
+  const registeredComponent = $derived(fieldComponentRegistry.resolveFieldComponent(schema));
 
   /**
    * Field label - prefer title, fall back to description, then key
@@ -386,6 +393,23 @@
         {workflowId}
         {authProvider}
         onChange={(val) => onChange(val)}
+      />
+    {:else if fieldType === 'autocomplete' && schema.autocomplete && registeredComponent}
+      <!--
+        A consumer has registered a custom component that matches this
+        autocomplete field (e.g. a dependent-autocomplete that needs sibling
+        form values). Render that instead of the built-in FormAutocomplete.
+      -->
+      <registeredComponent.component
+        id={fieldKey}
+        value={autocompleteValue}
+        autocomplete={schema.autocomplete}
+        dependencies={schema.dependencies}
+        placeholder={schema.placeholder ?? ''}
+        {required}
+        ariaDescribedBy={descriptionId}
+        disabled={isReadOnly}
+        onChange={(val: unknown) => onChange(val)}
       />
     {:else if fieldType === 'autocomplete' && schema.autocomplete}
       <FormAutocomplete

--- a/libs/flowdrop/src/lib/components/form/FormFieldLight.svelte
+++ b/libs/flowdrop/src/lib/components/form/FormFieldLight.svelte
@@ -243,6 +243,8 @@
         spellChecker={schema.spellChecker as boolean | undefined}
         variables={schema.variables}
         placeholderExample={schema.placeholderExample as string | undefined}
+        autocomplete={schema.autocomplete}
+        dependencies={schema.dependencies}
         onChange={(val: unknown) => onChange(val)}
       />
     {:else if fieldType === 'checkbox-group'}

--- a/libs/flowdrop/src/lib/components/form/types.ts
+++ b/libs/flowdrop/src/lib/components/form/types.ts
@@ -312,6 +312,14 @@ export interface FieldSchema {
   /** Autocomplete configuration for fetching suggestions from callback URL */
   autocomplete?: AutocompleteConfig;
   /**
+   * Map of URL query-parameter name → sibling field name. When a registered
+   * autocomplete component is rendered, dependency values can be read from the
+   * form via the `flowdrop:getFormValues` context and appended to the
+   * autocomplete fetch URL. The built-in `FormAutocomplete` does not consume
+   * this map directly; it is forwarded to registered components.
+   */
+  dependencies?: Record<string, string>;
+  /**
    * Whether the field is read-only (JSON Schema readOnly keyword).
    * When true, the field is displayed but cannot be edited.
    */

--- a/libs/flowdrop/src/lib/form/autocomplete.ts
+++ b/libs/flowdrop/src/lib/form/autocomplete.ts
@@ -1,0 +1,20 @@
+/**
+ * FlowDrop Form Autocomplete Module
+ *
+ * Re-exports the built-in `FormAutocomplete` component so consumers can wrap
+ * it in custom field components (for example a dependent-autocomplete that
+ * needs to read sibling form values) without reimplementing type-ahead,
+ * debouncing, and label caching themselves.
+ *
+ * @module form/autocomplete
+ *
+ * @example
+ * ```svelte
+ * <script lang="ts">
+ *   import FormAutocomplete from "@flowdrop/flowdrop/form/autocomplete";
+ * </script>
+ * ```
+ */
+
+export { default } from '../components/form/FormAutocomplete.svelte';
+export { default as FormAutocomplete } from '../components/form/FormAutocomplete.svelte';


### PR DESCRIPTION
## Summary

Implements the four API extensions proposed in #29 so consumers can build custom dependent-autocomplete field components without forking the library.

- **`flowdrop:getFormValues` context** in `ConfigForm.svelte` — registered field components can read sibling form values to resolve `dependencies`.
- **Registry branch in `FormField.svelte`** — mirrors the existing branch in `FormFieldLight.svelte`, so custom components registered via `fieldComponentRegistry` get rendered in the full form too, with `autocomplete` and `dependencies` props forwarded.
- **`autocomplete` / `dependencies` props forwarded in `FormFieldLight.svelte`** — the registered-component branch now passes both through, matching the new `FormField` branch.
- **`FieldSchema.dependencies`** type added in `form/types.ts` — `Record<string, string>` mapping URL param → sibling field name.
- **`form/autocomplete` subpath export** — new `src/lib/form/autocomplete.ts` barrel re-exports `FormAutocomplete` so consumers can wrap it without reaching into private paths; corresponding entry added to `package.json` `exports`.

Together these are the minimum hooks needed for a downstream app to ship its own dependent-autocomplete field (e.g. an autocomplete whose query depends on the value of another field in the same form) using only public API.

Closes #29.

## Test plan

- [x] `prettier --check` on changed files (clean)
- [x] `svelte-check` on touched files (no new errors; one pre-existing error in `Playground.svelte` is unrelated)
- [ ] Maintainer review of API surface
- [ ] Consumer smoke test: register a custom component that reads `getContext('flowdrop:getFormValues')` and renders `FormAutocomplete` with `dependencies`